### PR TITLE
Ability to customize twig cache directory

### DIFF
--- a/src/TwigView.php
+++ b/src/TwigView.php
@@ -82,7 +82,7 @@ class TwigView implements View
 
     public function cacheDir()
     {
-        $cacheDirPath = WP_CONTENT_DIR . '/cache/twig';
+        $cacheDirPath = WP_OFFBEAT_TWIG_CACHE_DIR ?? WP_CONTENT_DIR . '/cache/twig';
 
         if (!is_dir($cacheDirPath)) {
             mkdir($cacheDirPath);


### PR DESCRIPTION
This is useful when running in a container, this way you can store twig caches inside the container and not in a volume with the rest of the cache.